### PR TITLE
Add test coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           bundler-cache: true
 
       - name: Run Test
-        run: rake test
+        run: bundle exec rake
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,3 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,8 @@ jobs:
 
       - name: Run Test
         run: rake test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'minitest', '5.20.0'
+gem 'rake', '13.1.0'
+gem 'simplecov', '0.22.0', require: false
+gem 'simplecov-cobertura', '2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    docile (1.4.0)
     minitest (5.20.0)
+    rake (13.1.0)
+    rexml (3.2.6)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
   minitest (= 5.20.0)
+  rake (= 13.1.0)
+  simplecov (= 0.22.0)
+  simplecov-cobertura (= 2.1.0)
 
 BUNDLED WITH
    2.4.18

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Leet Code Ruby
 
 [![gh-actions](https://github.com/terenceponce/leetcode-ruby/workflows/CI/badge.svg)](https://github.com/terenceponce/leetcode-ruby/actions?workflow=CI)
+[![codecov](https://codecov.io/gh/terenceponce/leetcode-ruby/graph/badge.svg?token=yrvUXgdNNl)](https://codecov.io/gh/terenceponce/leetcode-ruby)
 
 These are my solutions for Leet Code problems written in Ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require 'minitest/test_task'
-
-Minitest::TestTask.create(:test) do |t|
-  t.libs << 'test'
-  t.libs << 'lib'
-  t.warning = false
-  t.test_globs = ['test/**/*_test.rb']
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/*_test.rb'
+  test.verbose = true
 end
 
 task default: :test

--- a/test/solutions/0001_two_sum/two_sum_test.rb
+++ b/test/solutions/0001_two_sum/two_sum_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'test_helper'
 require_relative '../../../lib/solutions/0001_two_sum/two_sum'
 
 class TwoSumTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+require 'simplecov-cobertura'
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+
+require 'minitest/autorun'


### PR DESCRIPTION
This adds simplecov to produce coverage reports.

This also integrates CodeCov.io to send the coverage reports to.